### PR TITLE
fix: Fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ julia:
 notifications:
   email: false
 before_install:
-  - http://dist.neo4j.org/neo4j-community-3.3.5-unix.tar.gz
+  - wget dist.neo4j.org/neo4j-community-3.3.5-unix.tar.gz
   - tar -xzf neo4j-community-3.3.5-unix.tar.gz
   - sed -i 's/#dbms.security.auth_enabled=false/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j-server.properties
   - sed -i 's/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j-server.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ notifications:
 before_install:
   - wget dist.neo4j.org/neo4j-community-3.3.5-unix.tar.gz
   - tar -xzf neo4j-community-3.3.5-unix.tar.gz
-  - sed -i 's/#dbms.security.auth_enabled=false/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j-server.properties
-  - sed -i 's/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j-server.properties
+  - sed -i 's/#dbms.security.auth_enabled=false/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j.conf
+  - sed -i 's/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j.conf
   - neo4j-community-3.3.5/bin/neo4j start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 julia:
   - 0.6
-  - nightly
 notifications:
   email: false
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: julia
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false
 before_install:
-  - wget dist.neo4j.org/neo4j-community-2.3.4-unix.tar.gz
-  - tar -xzf neo4j-community-2.3.4-unix.tar.gz
-  - sed -i 's/#dbms.security.auth_enabled=false/dbms.security.auth_enabled=false/g' neo4j-community-2.3.4/conf/neo4j-server.properties
-  - sed -i 's/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g' neo4j-community-2.3.4/conf/neo4j-server.properties
-  - neo4j-community-2.3.4/bin/neo4j start
+  - http://dist.neo4j.org/neo4j-community-3.3.5-unix.tar.gz
+  - tar -xzf neo4j-community-3.3.5-unix.tar.gz
+  - sed -i 's/#dbms.security.auth_enabled=false/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j-server.properties
+  - sed -i 's/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g' neo4j-community-3.3.5/conf/neo4j-server.properties
+  - neo4j-community-3.3.5/bin/neo4j start

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.6
 Compat 0.7.13
 JSON
 Requests

--- a/src/Neo4j.jl
+++ b/src/Neo4j.jl
@@ -24,6 +24,15 @@ const QueryData = Union{Dict{Any,Any},Void}
 # Connection
 # ----------
 
+"""
+   Connection()
+
+### Examples
+```julia-repl
+julia> con = Neo4j.Connection("localhost")
+Neo4j.Connection(false, "localhost", 7474, "/db/data/", "http://localhost:7474/db/data/", "", "")
+```
+"""
 struct Connection
   tls::Bool
   host::AbstractString #UTF8String
@@ -64,20 +73,20 @@ end
 
 struct Graph
     # TODO extensions
-    node::AbstractString #UTF8String
-    node_index::AbstractString #UTF8String
-    relationship_index::AbstractString #UTF8String
-    extensions_info::AbstractString #UTF8String
-    relationship_types::AbstractString #UTF8String
-    batch::AbstractString #UTF8String
-    cypher::AbstractString #UTF8String
-    indexes::AbstractString #UTF8String
-    constraints::AbstractString #UTF8String
-    transaction::AbstractString #UTF8String
-    node_labels::AbstractString #UTF8String
-    version::AbstractString #UTF8String
+    node::AbstractString                  #UTF8String
+    node_index::AbstractString            #UTF8String
+    relationship_index::AbstractString    #UTF8String
+    extensions_info::AbstractString       #UTF8String
+    relationship_types::AbstractString    #UTF8String
+    batch::AbstractString                 #UTF8String
+    cypher::AbstractString                #UTF8String
+    indexes::AbstractString               #UTF8String
+    constraints::AbstractString           #UTF8String
+    transaction::AbstractString           #UTF8String
+    node_labels::AbstractString           #UTF8String
+    version::AbstractString               #UTF8String
     connection::Connection
-    relationship::AbstractString #UTF8String # Not in the spec
+    relationship::AbstractString          #UTF8String # Not in the spec
 end
 
 # UTF8String

--- a/src/Neo4j.jl
+++ b/src/Neo4j.jl
@@ -34,16 +34,17 @@ Neo4j.Connection(false, "localhost", 7474, "/db/data/", "http://localhost:7474/d
 ```
 """
 struct Connection
-  tls::Bool
-  host::AbstractString #UTF8String
-  port::Int
-  path::AbstractString #UTF8String
-  url::AbstractString #UTF8String
-  user::AbstractString #UTF8String
-  password::AbstractString #UTF8String
+   host::AbstractString #UTF8String
+   tls::Bool
+   port::Int
+   path::AbstractString #UTF8String
+   url::AbstractString #UTF8String
+   user::AbstractString #UTF8String
+   password::AbstractString #UTF8String
 
-  Connection{T <: AbstractString}(host::T; port = DEFAULT_PORT, path = DEFAULT_URI, tls = false, user = "", password = "") = new(tls, string(host), port, string(path), string("http://$host:$port$path"), string(user), string(password))
-  Connection() = new(DEFAULT_HOST)
+   Connection{T <: AbstractString}(host::T; port = DEFAULT_PORT, path = DEFAULT_URI, tls = false, user = "", password = "") = 
+      new(string(host), tls, port, string(path), string("http://$host:$port$path"), string(user), string(password))
+   Connection() = Connection(DEFAULT_HOST)
 end
 
 function connurl(c::Connection)

--- a/src/Neo4j.jl
+++ b/src/Neo4j.jl
@@ -14,17 +14,17 @@ const DEFAULT_HOST = "localhost"
 const DEFAULT_PORT = 7474
 const DEFAULT_URI = "/db/data/"
 
-typealias JSONObject{T <: AbstractString} Union{Dict{T,Any},Void}  # UTF8String
-typealias JSONArray Union{Vector,Void}
-typealias JSONData{T <: AbstractString} Union{JSONObject,JSONArray,T,Number,Void}
+const JSONObject{T <: AbstractString} = Union{Dict{T,Any},Void}  # UTF8String
+const JSONArray = Union{Vector,Void}
+const JSONData{T <: AbstractString} = Union{JSONObject,JSONArray,T,Number,Void}
 
-typealias QueryData Union{Dict{Any,Any},Void}
+const QueryData = Union{Dict{Any,Any},Void}
 
 # ----------
 # Connection
 # ----------
 
-immutable Connection
+struct Connection
   tls::Bool
   host::AbstractString #UTF8String
   port::Int
@@ -33,7 +33,7 @@ immutable Connection
   user::AbstractString #UTF8String
   password::AbstractString #UTF8String
 
-  Connection{T <: AbstractString}(host::T; port=DEFAULT_PORT, path=DEFAULT_URI, tls=false, user="", password="") = new(tls, string(host), port, string(path), string("http://$host:$port$path"), string(user), string(password))
+  Connection{T <: AbstractString}(host::T; port = DEFAULT_PORT, path = DEFAULT_URI, tls = false, user = "", password = "") = new(tls, string(host), port, string(path), string("http://$host:$port$path"), string(user), string(password))
   Connection() = new(DEFAULT_HOST)
 end
 
@@ -42,7 +42,7 @@ function connurl(c::Connection)
   "$(proto)://$(c.host):$(c.port)$(c.path)"
 end
 
-function connurl{T <: AbstractString}(c::Connection, suffix::T)
+function connurl(c::Connection, suffix::T) where {T <: AbstractString}
   url = connurl(c)
   "$(url)$(suffix)"
 end
@@ -62,7 +62,7 @@ end
 # Graph
 # -----
 
-immutable Graph
+struct Graph
     # TODO extensions
     node::AbstractString #UTF8String
     node_index::AbstractString #UTF8String
@@ -104,7 +104,7 @@ end
 # Node
 # ----
 
-immutable Node
+struct Node
     # TODO extensions
     paged_traverse::AbstractString #UTF8String
     labels::AbstractString #UTF8String
@@ -139,7 +139,7 @@ end
 # Statements
 # ----------
 
-immutable Statement
+struct Statement
   statement::AbstractString
   parameters::Dict
 end
@@ -148,7 +148,7 @@ end
 # Results
 # -------
 
-immutable Result
+struct Result
   results::Vector
   errors::Vector
 end
@@ -163,18 +163,18 @@ include("transaction.jl")
 # Requests
 # --------
 
-function request{T <: AbstractString}(url::AbstractString, method::Function, exp_code::Int,
-                 headers::Dict{T, T}; json::JSONData=nothing, # ASCIIString,ASCIIString
-                 query::QueryData=nothing)
+function request(url::AbstractString, method::Function, exp_code::Int,
+                 headers::Dict{T, T}; json::JSONData = nothing, # ASCIIString,ASCIIString
+                 query::QueryData = nothing) where {T <: AbstractString}
     if json == nothing && query == nothing
-        resp = method(url; headers=headers)
+        resp = method(url; headers = headers)
     elseif json == nothing
-        resp = method(url; headers=headers, query=query)
+        resp = method(url; headers = headers, query = query)
     elseif query == nothing
-        resp = method(url; headers=headers, json=json)
+        resp = method(url; headers = headers, json = json)
     else
         # TODO Figure out if this should ever occur and change it to an error if not
-        resp = method(url; headers=headers, json=json, query=query)
+        resp = method(url; headers = headers, json = json, query=query)
     end
     if resp.status !== exp_code
         respdata = Requests.json(resp)
@@ -191,7 +191,7 @@ end
 # External requests
 # -----------------
 
-function createnode(graph::Graph, props::JSONData=nothing)
+function createnode(graph::Graph, props::JSONData = nothing)
     resp = request(graph.node, Requests.post, 201, connheaders(graph.connection); json=props)
     jsrsp = Dict{AbstractString,Any}(Requests.json(resp)) # UTF8String
     # @show typeof(jsrsp)
@@ -217,12 +217,12 @@ function deletenode(graph::Graph, id::Int)
     deletenode(node)
 end
 
-function setnodeproperty{T <: AbstractString}(node::Node, name::T, value::Any)
+function setnodeproperty(node::Node, name::T, value::Any) where {T <: AbstractString}
     url = replace(node.property, "{key}", name)
     request(url, Requests.put, 204, connheaders(node.graph.connection); json=value)
 end
 
-function setnodeproperty{T <: AbstractString}(graph::Graph, id::Int, name::T, value::Any)
+function setnodeproperty(graph::Graph, id::Int, name::T, value::Any) where {T <: AbstractString}
     node = getnode(graph, id)
     setnodeproperty(node, name, value)
 end
@@ -231,7 +231,7 @@ function updatenodeproperties(node::Node, props::JSONObject)
     resp = request(node.properties, Requests.put, 204, connheaders(node.graph.connection); json=props)
 end
 
-function getnodeproperty{T <: AbstractString}(node::Node, name::T)
+function getnodeproperty(node::Node, name::T) where {T <: AbstractString}
     url = replace(node.property, "{key}", name)
     resp = request(url, Requests.get, 200, connheaders(node.graph.connection))
     Requests.json(resp)
@@ -251,12 +251,12 @@ function deletenodeproperties(node::Node)
     request(node.properties, Requests.delete, 204, connheaders(node.graph.connection))
 end
 
-function deletenodeproperty{T <: AbstractString}(node::Node, name::T)
+function deletenodeproperty(node::Node, name::T) where {T <: AbstractString}
     url = replace(node.property, "{key}", name)
     request(url, Requests.delete, 204, connheaders(node.graph.connection))
 end
 
-function addnodelabel{T <: AbstractString}(node::Node, label::T)
+function addnodelabel(node::Node, label::T) where {T <: AbstractString}
     request(node.labels, Requests.post, 204, connheaders(node.graph.connection); json=label)
 end
 
@@ -268,7 +268,7 @@ function updatenodelabels(node::Node, labels::JSONArray)
     request(node.labels, Requests.put, 204, connheaders(node.graph.connection); json=labels)
 end
 
-function deletenodelabel{T <: AbstractString}(node::Node, label::T)
+function deletenodelabel(node::Node, label::T) where {T <: AbstractString}
     url = "$(node.labels)/$label"
     request(url, Requests.delete, 204, connheaders(node.graph.connection))
 end
@@ -278,7 +278,7 @@ function getnodelabels(node::Node)
     Requests.json(resp)
 end
 
-function getnodesforlabel{T <: AbstractString}(graph::Graph, label::T, props::JSONObject=nothing)
+function getnodesforlabel(graph::Graph, label::T, props::JSONObject=nothing) where {T <: AbstractString}
     # TODO Shouldn't this url be available in the api somewhere?
     url = "$(graph.connection.url)label/$label/nodes"
     resp = request(url, Requests.get, 200, connheaders(graph.connection); query=props)
@@ -294,7 +294,7 @@ end
 # Relationships
 # -------------
 
-immutable Relationship
+struct Relationship
     relstart::AbstractString #UTF8String
     property::AbstractString #UTF8String
     self::AbstractString #UTF8String
@@ -311,7 +311,7 @@ Relationship(data::JSONObject, graph::Graph) = Relationship(data["start"], data[
         data["self"], data["properties"], data["metadata"], data["type"], data["end"], data["data"],
         split(data["self"], "/")[end] |> parse, graph)
 
-function getrels(node::Node; incoming::Bool=true, outgoing::Bool=true)
+function getrels(node::Node; incoming::Bool = true, outgoing::Bool = true)
   rels = Vector{Relationship}()
   if(incoming)
     resp = request(node.incoming_relationships, Requests.get, 200, connheaders(node.graph.connection))
@@ -328,19 +328,19 @@ function getrels(node::Node; incoming::Bool=true, outgoing::Bool=true)
   rels
 end
 
-function getneighbors(node::Node; incoming::Bool=true, outgoing::Bool=true)
+function getneighbors(node::Node; incoming::Bool = true, outgoing::Bool = true)
   neighbors = Vector{Node}()
 
   # Do incoming
   if(incoming)
-    rels = getrels(node, incoming=true, outgoing=false)
+    rels = getrels(node, incoming = true, outgoing = false)
     for rel=rels
       resp = request(rel.relstart, Requests.get, 200, connheaders(node.graph.connection))
       push!(neighbors, Node(Dict{AbstractString,Any}(Requests.json(resp)), node.graph))  # UTF8String
     end
   end
   if(outgoing)
-    rels = getrels(node, incoming=false, outgoing=true)
+    rels = getrels(node, incoming = false, outgoing = true)
     for rel=rels
       resp = request(rel.relend, Requests.get, 200, connheaders(node.graph.connection))
       push!(neighbors, Node(Dict{AbstractString,Any}(Requests.json(resp)), node.graph))  # UTF8String

--- a/src/transaction.jl
+++ b/src/transaction.jl
@@ -4,7 +4,6 @@
 # requests as a means of batching jobs together.
 
 using Compat
-import Base.call
 
 export transaction, rollback, commit
 

--- a/src/transaction.jl
+++ b/src/transaction.jl
@@ -8,7 +8,7 @@ import Base.call
 
 export transaction, rollback, commit
 
-immutable Transaction
+struct Transaction
   conn::Connection
   commit::AbstractString
   location::AbstractString


### PR DESCRIPTION
Fixed deprecations by following changes: 
- `immutable` to `struct`
- change of parameter type definitions from `f{T<:type}`  to `f(x::T) where {T<:type}`
- `typealias` with `const` syntax, e.g. `typealias JSONArray Union{Vector,Void}` to `const JSONArray = Union{Vector,Void}`

-> Run `Pkg.test("Neo4j")` with output: All tests passed!