### PR TITLE
cypherQuery: Return DataFrames.DataFrame from MATCH query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: julia
 julia:
   - 0.6
+  - nightly
 notifications:
   email: false
+## (tests will run but not make your overall status red)
+matrix:
+ allow_failures:
+ - julia: nightly
+
 before_install:
   - wget dist.neo4j.org/neo4j-community-3.3.5-unix.tar.gz
   - tar -xzf neo4j-community-3.3.5-unix.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-  - 0.6
+  - 0.6.1
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-  - 0.6.1
+  - 0.6.0
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Rollbacks are also supported:
 ```julia
 rollback(tx)
 ```
+
+If the goal is to simply run a MATCH query and having the result in the form of a 
+`DataFrames.DataFrame` object, the `cypherQuery` function can be used.
+The `cypherQuery` implementation performs the query in a single trnsaction which 
+automatically opens and closes the transaction:
+
+```julia
+results = cypherQuery("MATCH (n) RETURN n.property AS Property")
+```

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,5 @@ julia 0.6
 Compat 0.7.13
 JSON
 Requests
+DataFrames
+Missings

--- a/src/Neo4j.jl
+++ b/src/Neo4j.jl
@@ -7,7 +7,7 @@ export getgraph, version, createnode, getnode, deletenode, setnodeproperty, getn
        getnodeproperties, updatenodeproperties, deletenodeproperties, deletenodeproperty,
        addnodelabel, addnodelabels, updatenodelabels, deletenodelabel, getnodelabels,
        getnodesforlabel, getlabels, getrel, getrels, getneighbors, createrel, deleterel, getrelproperty,
-       getrelproperties, updaterelproperties
+       getrelproperties, updaterelproperties, cypherQuery
 export Connection, Result
 
 const DEFAULT_HOST = "localhost"
@@ -392,5 +392,10 @@ end
 function updaterelproperties(rel::Relationship, props::JSONObject)
     request(rel.properties, Requests.put, 204, connheaders(rel.graph.connection); json=props)
 end
+
+# ------------
+# Cypher query
+# ------------
+include("cypherQuery.jl")
 
 end # module

--- a/src/cypherQuery.jl
+++ b/src/cypherQuery.jl
@@ -46,7 +46,7 @@ function cypherQuery(
    end
    # parse results into data sink
    # Result(respdata["results"], respdata["errors"])
-   if !isempty(respdata["results"])
+   if !isempty(respdata["results"][1]["data"])
       return parseResults(respdata["results"][1], elTypes = elTypes, nRowsElTypeCheck = nRowsElTypeCheck);
    else
       return DataFrames.DataFrame();

--- a/src/cypherQuery.jl
+++ b/src/cypherQuery.jl
@@ -1,11 +1,34 @@
 
+using DataFrames, Missings;
 
+"""
+   cypherQuery(conn, cypher, params...; elTypes, nRowsElTypeCheck)
+
+Retrieve molecular identifier from other databases, `targetDb`, for single or mulitple query IDs, `queryId`,
+and moreover information on Ensembl gene, transcript and peptide IDs, such as ID and genomic loation.
+
+### Arguments
+- `conn::Neo4j.Connection` : a valid connection to a Neo4j graph DB instance.
+- `cypher::String` : Cypher `MATCH` query returning tabular data.
+- `params::Pair` : parameters which are passed on to the cypher query.
+- `elTypes::Vector{Type}` : column types can be provided manually as a Vector{Type}
+- `nRowsElTypeCheck::Int` : Number of rows which are used to determine column datatypes (defaults to 1000)
+
+### Examples
+```julia-repl
+julia> cypherQuery(
+         Neo4j.Connection("localhost"), 
+         "MATCH (p :Person {name: {name}}) RETURN p.name AS Name, p.age AS Age;", 
+         "name" => "John Doe")
+
+```
+"""
 function cypherQuery(
       conn::Connection, 
       cypher::AbstractString, 
       params::Pair...;
-      elTypes::Vector{Type} = Vector{Type}(),
-      nRowsElTypeCheck::Int = 0)
+      elTypes::Vector{DataType} = Vector{DataType}(),
+      nRowsElTypeCheck::Int = 1000)
    
    url = connurl(conn, "transaction/commit")
    headers = connheaders(conn)
@@ -17,23 +40,31 @@ function cypherQuery(
      error("Failed to commit transaction ($(resp.status)): $(txn)\n$(resp)")
    end
    respdata = Requests.json(resp)
- 
-   # parse results into data sink
-   result = parseResults(respdata["results"][1], nRowsElTypeCheck);
-   # Result(respdata["results"], respdata["errors"])
 
-   return result;
+   if !isempty(respdata["errors"])
+      error(join(map(i -> (i * ": " * respdata["errors"][1][i]), keys(respdata["errors"][1])), "\n"));
+   end
+   # parse results into data sink
+   # Result(respdata["results"], respdata["errors"])
+   if !isempty(respdata["results"])
+      return parseResults(respdata["results"][1], elTypes = elTypes, nRowsElTypeCheck = nRowsElTypeCheck);
+   else
+      return DataFrames.DataFrame();
+   end
 end
 
 # Currently only supports DataFrames.DataFrame objects
 #  -> Future: Allow different data sink types, such as tables from JuliaDB
-function parseResults(res::Dict{String, Any}, nRows::Int)
+function parseResults(res::Dict{String, Any}; elTypes::Vector{DataType} = Vector(), nRowsElTypeCheck::Int = 100)
    # Get elementary types from a column where there is no NA value (nothing)
-   elTypes = getElTypes(res["data"], nRows);
+   if isempty(elTypes)
+      elTypes = getElTypes(res["data"], nRowsElTypeCheck);
+   end
    colNames = collect(Symbol, res["columns"]);
    nRows = length(res["data"]);
 
    x = DataFrames.DataFrame(elTypes, colNames, nRows);
+
    for (rowIdx, rowVal) in enumerate(res["data"])
       for (colIdx,colVal) in enumerate(rowVal["row"])
          if colVal != nothing
@@ -45,40 +76,33 @@ function parseResults(res::Dict{String, Any}, nRows::Int)
    return x;
 end
 
-function getElTypes(x::Vector{Any}, nRows::Int)
+function getElTypes(x::Vector{Any}, nRowsElTypeCheck::Int = 0)
    nRecords = length(x);
    elTypes::Vector{Type} = Type[Union{Void, Missings.Missing} for i in 1:length(x[1]["row"])];
-   elTypes = Type[Union{Void, Missings.Missing} for i in 1:length(x[1]["row"])];
-   # for now simple, later maybe for each column individually
-   nMaxRows = (nRows != 0 && nRows < nMaxRows) ? nRows : nRecords;
+   nMaxRows = nRecords;
+   # elTypes = Type[Union{Void, Missings.Missing} for i in 1:length(x[1]["row"])];
+   nMaxRows = (nRowsElTypeCheck != 0 && nRowsElTypeCheck <= nMaxRows) ? nRowsElTypeCheck : nRecords;
    checkIdx = trues(length(x[1]["row"]));
    for i in 1:nMaxRows
-      # if !any(map(i->i == nothing, x[i]["row"]))
-         # check each column individually
-         for el in find(checkIdx)
-            if !(x[i]["row"][el] == nothing)
-               if !(typeof(x[i]["row"][el]) === Array{Any,1})
-                  elTypes[el] = i > 1 ? 
-                        Union{typeof(x[i]["row"][el]), Missings.Missing} : 
-                        typeof(x[i]["row"][el]);
-               else
-                  elTypes[el] = i > 1 ? 
-                        Union{Vector{typeof(x[i]["row"][el][1])}, Missings.Missing} :
-                        Vector{typeof(x[i]["row"][el][1])};
-               end
-               checkIdx[el] = false;
+      # check each column individually
+      for el in find(checkIdx)
+         if !(x[i]["row"][el] == nothing)
+            if !(typeof(x[i]["row"][el]) === Array{Any,1})
+               elTypes[el] = i > 1 ? 
+                     Union{typeof(x[i]["row"][el]), Missings.Missing} : 
+                     typeof(x[i]["row"][el]);
+            else
+               elTypes[el] = i > 1 ? 
+                     Union{Vector{typeof(x[i]["row"][el][1])}, Missings.Missing} :
+                     Vector{typeof(x[i]["row"][el][1])};
             end
+            checkIdx[el] = false;
          end
-         # elTypes = map(i->Union{typeof(i)}, x[i]["row"]);
-         if isempty(find(checkIdx))
-            break;
-         end
-      # end
+      end
+      if isempty(find(checkIdx))
+         break;
+      end
    end
-   # if any(getfield.(elTypes, :a) .=== Void)
-   #    # warn("one or more columns only contain NA values");
-   #    elTypes = map(i->Union{typeof(i),Missings.Missing}, x[1]["row"]);
-   #    elTypes[elTypes .== Void] = Union{Void, Missings.Missing};
-   # end
+
    return elTypes;
 end

--- a/src/cypherQuery.jl
+++ b/src/cypherQuery.jl
@@ -1,0 +1,84 @@
+
+
+function cypherQuery(
+      conn::Connection, 
+      cypher::AbstractString, 
+      params::Pair...;
+      elTypes::Vector{Type} = Vector{Type}(),
+      nRowsElTypeCheck::Int = 0)
+   
+   url = connurl(conn, "transaction/commit")
+   headers = connheaders(conn)
+   body = Dict("statements" => [Statement(cypher, Dict(params))])
+ 
+   resp = Requests.post(url; headers=headers, json=body)
+ 
+   if resp.status != 200
+     error("Failed to commit transaction ($(resp.status)): $(txn)\n$(resp)")
+   end
+   respdata = Requests.json(resp)
+ 
+   # parse results into data sink
+   result = parseResults(respdata["results"][1], nRowsElTypeCheck);
+   # Result(respdata["results"], respdata["errors"])
+
+   return result;
+end
+
+# Currently only supports DataFrames.DataFrame objects
+#  -> Future: Allow different data sink types, such as tables from JuliaDB
+function parseResults(res::Dict{String, Any}, nRows::Int)
+   # Get elementary types from a column where there is no NA value (nothing)
+   elTypes = getElTypes(res["data"], nRows);
+   colNames = collect(Symbol, res["columns"]);
+   nRows = length(res["data"]);
+
+   x = DataFrames.DataFrame(elTypes, colNames, nRows);
+   for (rowIdx, rowVal) in enumerate(res["data"])
+      for (colIdx,colVal) in enumerate(rowVal["row"])
+         if colVal != nothing
+            x[rowIdx,colIdx] = colVal;
+         end
+      end
+   end
+
+   return x;
+end
+
+function getElTypes(x::Vector{Any}, nRows::Int)
+   nRecords = length(x);
+   elTypes::Vector{Type} = Type[Union{Void, Missings.Missing} for i in 1:length(x[1]["row"])];
+   elTypes = Type[Union{Void, Missings.Missing} for i in 1:length(x[1]["row"])];
+   # for now simple, later maybe for each column individually
+   nMaxRows = (nRows != 0 && nRows < nMaxRows) ? nRows : nRecords;
+   checkIdx = trues(length(x[1]["row"]));
+   for i in 1:nMaxRows
+      # if !any(map(i->i == nothing, x[i]["row"]))
+         # check each column individually
+         for el in find(checkIdx)
+            if !(x[i]["row"][el] == nothing)
+               if !(typeof(x[i]["row"][el]) === Array{Any,1})
+                  elTypes[el] = i > 1 ? 
+                        Union{typeof(x[i]["row"][el]), Missings.Missing} : 
+                        typeof(x[i]["row"][el]);
+               else
+                  elTypes[el] = i > 1 ? 
+                        Union{Vector{typeof(x[i]["row"][el][1])}, Missings.Missing} :
+                        Vector{typeof(x[i]["row"][el][1])};
+               end
+               checkIdx[el] = false;
+            end
+         end
+         # elTypes = map(i->Union{typeof(i)}, x[i]["row"]);
+         if isempty(find(checkIdx))
+            break;
+         end
+      # end
+   end
+   # if any(getfield.(elTypes, :a) .=== Void)
+   #    # warn("one or more columns only contain NA values");
+   #    elTypes = map(i->Union{typeof(i),Missings.Missing}, x[1]["row"]);
+   #    elTypes[elTypes .== Void] = Union{Void, Missings.Missing};
+   # end
+   return elTypes;
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,4 +251,26 @@ rollresult = rolltx("MATCH (n:Neo4jjl) WHERE n.name = 'John Doe' RETURN n"; subm
 @test length(rollresult.errors) == 0
 
 println("Success!");
+
+
+# --- New cypherQuery using transaction/commit endpoint ---
+
+print("[TEST] MATCH node and return DataFrame using cypherQuery()...")
+
+# Open transaction and create node
+loadtx = transaction(conn)
+createnode(loadtx, "John Doe", 20; submit=true)
+Neo4j.commit(loadtx)
+
+matchresult = cypherQuery(conn, 
+                  "MATCH (n:Neo4jjl {name: {name}}) RETURN n.name AS Name, n.age AS Age;", 
+                  "name" => "John Doe")
+@test DataFrames.DataFrame(Name = "John Doe", Age = 20) == matchresult
+
+# Cleanup
+deletetx = transaction(conn)
+deletetx(query, "age" => 20)
+deleteresult = commit(deletetx)
+
+println("Success!");
 println("--- All tests passed!");


### PR DESCRIPTION
`cypherQuery` uses the 'transaction/commit' endpoint and does not need a separate transaction anymore as it is a single transaction call.
It allows querying for tabular results and returns a DataFrames.DataFrame object.
