### PR TITLE
Use generators instead of mapping over a set

### DIFF
--- a/src/cypherQuery.jl
+++ b/src/cypherQuery.jl
@@ -42,7 +42,9 @@ function cypherQuery(
    respdata = JSON.parse(String(resp.body))
 
    if !isempty(respdata["errors"])
-      error(join(map(i -> (i * ": " * respdata["errors"][1][i]), keys(respdata["errors"][1])), "\n"));
+     ks = (k for k in keys(respdata["errors"][1]))
+     es = (k * ": " * respdata["errors"][1][k] for k in ks)
+     error(join(es, "\n"));
    end
    # parse results into data sink
    # Result(respdata["results"], respdata["errors"])


### PR DESCRIPTION
Looking at https://github.com/glesica/Neo4j.jl/issues/16 it looks like mapping over sets no longer works in the latest versions of Julia. We can switch to using generators and make the code just a touch cleaner in the process. This should work in both new and old-ish versions.

Can someone verify this for me? Thanks!