### PR TITLE
Fix missing connection in cypherQuery in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ The `cypherQuery` implementation performs the query in a single transaction whic
 automatically opens and closes the transaction:
 
 ```julia
-results = cypherQuery("MATCH (n) RETURN n.property AS Property")
+results = cypherQuery(c, "MATCH (n) RETURN n.property AS Property")
 ```


### PR DESCRIPTION
Just a little documentation fix. I was wondering how it would magically know what connection to use : )