### PR TITLE
Add "content-type" to `connheaders()`

### DIFF
--- a/src/Neo4j.jl
+++ b/src/Neo4j.jl
@@ -62,6 +62,7 @@ end
 function connheaders(c::Connection)
   headers = Dict(
     "Accept" => "application/json; charset=UTF-8",
+    "content-type" => "application/json",
     "Host" => "$(c.host):$(c.port)")
   if c.user != "" && c.password != ""
     payload = "$(c.user):$(c.password)" |> base64encode


### PR DESCRIPTION
Neo4j [now requires](https://neo4j.com/docs/http-api/current/actions/begin-a-transaction/) a Content Type header in all API requests. I added it here by changing the `connheaders()` function.

```json
"content-type": "application/json"
```

```julia
function connheaders(c::Connection)
  headers = Dict(
    "Accept" => "application/json; charset=UTF-8",
    "content-type" => "application/json",
    "Host" => "$(c.host):$(c.port)")
  if c.user != "" && c.password != ""
    payload = "$(c.user):$(c.password)" |> base64encode
    headers["Authorization"] = "Basic $(payload)"
  end
  headers
end
```


For me, none of the functions were working until I added this. I am using Neo4j 4.3.6.

Thanks for your work, I am liking the automatic DataFrame feature.